### PR TITLE
Allow subfolders for resources #1

### DIFF
--- a/providers/coding_standard.rb
+++ b/providers/coding_standard.rb
@@ -12,7 +12,7 @@ def whyrun_supported?
 end
 
 action :install do
-  Chef::Log.debug 'install coding standard'
+  Chef::Log.info 'Installing coding standard #{new_resource.name}'
 
   php_dir = `pear config-get php_dir`.strip
   standards_dir = "#{php_dir}/PHP/CodeSniffer/Standards"

--- a/providers/coding_standard.rb
+++ b/providers/coding_standard.rb
@@ -14,8 +14,13 @@ end
 action :install do
   Chef::Log.info 'Installing coding standard #{new_resource.name}'
 
-  php_dir = `pear config-get php_dir`.strip
-  standards_dir = "#{php_dir}/PHP/CodeSniffer/Standards"
+  case node['phpcs']['install_method']
+  when 'pear'
+    php_dir = `pear config-get php_dir`.strip
+    standards_dir = "#{php_dir}/PHP/CodeSniffer/Standards"
+  when 'composer'
+    standards_dir = "#{Chef::Config[:file_cache_path]}/phpcs/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards"
+  end
 
   git "#{standards_dir}/#{new_resource.name}" do
     repository new_resource.repository

--- a/providers/coding_standard.rb
+++ b/providers/coding_standard.rb
@@ -37,7 +37,7 @@ action :install do
 
 
   if !new_resource.subfolder.nil?
-    bash "copy-drupal-standard" do
+    bash "phpcs: copy a standard from subfolder" do
       user "root"
       code <<-EOH
         cp -Rf #{Chef::Config[:file_cache_path]}/#{new_resource.name}/#{new_resource.subfolder} #{standards_dir}

--- a/providers/coding_standard.rb
+++ b/providers/coding_standard.rb
@@ -37,6 +37,13 @@ action :install do
 
 
   if !new_resource.subfolder.nil?
+    bash "phpcs: remove old standards folder" do
+      user "root"
+      code <<-EOH
+        rm -rf #{standards_dir}/#{new_resource.name}
+      EOH
+      only_if "test -d #{standards_dir}/#{new_resource.name}"
+    end
     bash "phpcs: copy a standard from subfolder" do
       user "root"
       code <<-EOH

--- a/resources/coding_standard.rb
+++ b/resources/coding_standard.rb
@@ -11,6 +11,7 @@ default_action :install
 attribute :name, :name_attribute => true, :kind_of => String, :default => nil
 attribute :repository, :kind_of => String, :default => nil
 attribute :reference, :kind_of => String, :default => nil
+attribute :subfolder, :kind_of => String, :default => nil
 
 def initialize(*args)
   super


### PR DESCRIPTION
This is convenient e.g. for Drupal standards, which are in a subfolder in the repository.

This also includes a fix for standards install when using the composer install method.