### PR TITLE
Updated composer.json name value

### DIFF
--- a/templates/default/composer.json.erb
+++ b/templates/default/composer.json.erb
@@ -1,5 +1,5 @@
 {
-    "name": "phpcs",
+    "name": "phpcs/phpcs",
     "description": "phpcs",
     "require": {
         "squizlabs/php_codesniffer": "<%= @version %>"


### PR DESCRIPTION
Fixes https://github.com/djoos-cookbooks/phpcs/issues/14 

Testing results:
```
==> default:   * template[/usr/local/phpcs/composer.json] action create[2020-12-15T18:01:50-06:00] INFO: template[/usr/local/phpcs/composer.json] created file /usr/local/phpcs/composer.json
==> default:
==> default:     - create new file /usr/local/phpcs/composer.json[2020-12-15T18:01:50-06:00] INFO: template[/usr/local/phpcs/composer.json] updated file contents /usr/local/phpcs/composer.json
==> default:
==> default:     - update content in file /usr/local/phpcs/composer.json from none to ab6689
==> default:     --- /usr/local/phpcs/composer.json	2020-12-15 18:01:50.607386286 -0600
==> default:     +++ /usr/local/phpcs/.chef-composer20201215-6238-tw8u21.json	2020-12-15 18:01:50.607386286 -0600
==> default:     @@ -1 +1,11 @@
==> default:     +{
==> default:     +    "name": "phpcs/phpcs",
==> default:     +    "description": "phpcs",
==> default:     +    "require": {
==> default:     +        "squizlabs/php_codesniffer": "1.5.2"
==> default:     +    },
==> default:     +    "config": {
==> default:     +        "bin-dir": "/usr/bin"
==> default:     +    }
==> default:     +}[2020-12-15T18:01:50-06:00] INFO: template[/usr/local/phpcs/composer.json] owner changed to 0
==> default: [2020-12-15T18:01:50-06:00] INFO: template[/usr/local/phpcs/composer.json] group changed to 0
==> default: [2020-12-15T18:01:50-06:00] INFO: template[/usr/local/phpcs/composer.json] mode changed to 600
==> default:
==> default:     - change mode from '' to '0600'
==> default:     - change owner from '' to 'root'
==> default:     - change group from '' to 'root'
==> default:
==> default:     - restore selinux security context
==> default:   * execute[phpcs-composer] action run
==> default:
==> default:     [execute] Do not run Composer as root/super user! See https://getcomposer.org/root for details
==> default:               Loading composer repositories with package information
==> default:               Updating dependencies
==> default:               Lock file operations: 1 install, 0 updates, 0 removals
==> default:                 - Locking squizlabs/php_codesniffer (1.5.2)
==> default:               Writing lock file
==> default:               Installing dependencies from lock file (including require-dev)
==> default:               Package operations: 1 install, 0 updates, 0 removals
==> default:                 - Downloading squizlabs/php_codesniffer (1.5.2)
==> default:                 - Installing squizlabs/php_codesniffer (1.5.2): Extracting archive
==> default:               1 package suggestions were added by new dependencies, use `composer suggest` to see details.
==> default:               Generating autoload files
==> default: [2020-12-15T18:01:55-06:00] INFO: execute[phpcs-composer] ran successfully
==> default:     - execute composer update
```

I was able to run the unit tests also:
```
[caryp@Carys-MacBook-Pro phpcs (master)]$ chef exec rake unit
/opt/chefdk/embedded/bin/ruby -I/opt/chefdk/embedded/lib/ruby/gems/2.6.0/gems/rspec-support-3.9.3/lib:/opt/chefdk/embedded/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.2/lib /opt/chefdk/embedded/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
No examples found.


Finished in 0.279 seconds (files took 2.22 seconds to load)
0 examples, 0 failures


  No Chef resources found, skipping coverage calculation...
```

But the Style and Integration tests seem out of date and had issues with this version of ChefDK:
```
[caryp@Carys-MacBook-Pro phpcs (master)]$ chef --version
ChefDK version: 4.9.7
Chef Infra Client version: 15.12.22
Chef InSpec version: 4.21.3
Test Kitchen version: 2.5.2
Foodcritic version: 16.3.0
Cookstyle version: 5.23.0
```

Please let me know if you need anything more to merge.

Thank you!!